### PR TITLE
ListBrowser Customizations

### DIFF
--- a/examples/list_browser.py
+++ b/examples/list_browser.py
@@ -1,8 +1,10 @@
+"""Example of using the Trame ListBrowser component."""
+
 import os
 
 from trame.app import get_server
-
 from trame.widgets import trame
+from trame.widgets import vuetify3 as v3
 
 server = get_server()
 server.client_type = os.environ.get("VUE_VERSION", "vue3")
@@ -12,7 +14,6 @@ if server.client_type == "vue2":
 else:
     from trame.ui.vuetify3 import SinglePageLayout
 
-from trame.widgets import vuetify3 as v3
 
 FILE_LISTING = [
     {
@@ -51,8 +52,9 @@ FILE_LISTING = FILE_LISTING + FILLER_DATA
 PATH_HIERARCHY = ["Home", "parent", "child"]
 
 
-def on_click(e):
-    print(e)
+def on_click(event: dict) -> None:
+    """Trigger when a ListBrowser item is clicked."""
+    print(event)
 
 
 with SinglePageLayout(server) as layout:
@@ -63,7 +65,7 @@ with SinglePageLayout(server) as layout:
             style=(
                 "height:700px; width:50%; margin-left: auto; margin-right: auto; margin-top: 50px;"
                 " border: 1px solid red;"
-            )
+            ),
         ):
             trame.ListBrowser(
                 classes="pa-8",

--- a/examples/list_browser.py
+++ b/examples/list_browser.py
@@ -58,9 +58,10 @@ def on_click(e):
 with SinglePageLayout(server) as layout:
     layout.title.set_text("List Browser")
     with layout.content:
+        # Dummy container to give you an idea of how it'd look in a floating card
         with v3.VContainer(
             style=(
-                "height:50%;width:50%;margin-left: auto;margin-right: auto; margin-top: 50px;"
+                "height:700px; width:50%; margin-left: auto; margin-right: auto; margin-top: 50px;"
                 " border: 1px solid red;"
             )
         ):

--- a/examples/list_browser.py
+++ b/examples/list_browser.py
@@ -1,5 +1,7 @@
 import os
+
 from trame.app import get_server
+
 from trame.widgets import trame
 
 server = get_server()
@@ -50,6 +52,8 @@ with SinglePageLayout(server) as layout:
             list=("listing", FILE_LISTING),
             path=("path", PATH_HIERARCHY),
             click=(on_click, "[$event]"),
+            path_separator="/",
+            show_path_with_icon=True,
         )
 
 if __name__ == "__main__":

--- a/examples/list_browser.py
+++ b/examples/list_browser.py
@@ -5,12 +5,14 @@ from trame.app import get_server
 from trame.widgets import trame
 
 server = get_server()
-server.client_type = os.environ.get("VUE_VERSION", "vue2")
+server.client_type = os.environ.get("VUE_VERSION", "vue3")
 
 if server.client_type == "vue2":
     from trame.ui.vuetify2 import SinglePageLayout
 else:
     from trame.ui.vuetify3 import SinglePageLayout
+
+from trame.widgets import vuetify3 as v3
 
 FILE_LISTING = [
     {
@@ -34,6 +36,18 @@ FILE_LISTING = [
     },
 ]
 
+FILLER_DATA = [
+    {
+        "text": f"File_{i}.txt",
+        "value": f"file_{i}.txt",
+        "type": "File",
+        "prependIcon": "mdi-file-document-outline",
+    }
+    for i in range(40)
+]
+
+FILE_LISTING = FILE_LISTING + FILLER_DATA
+
 PATH_HIERARCHY = ["Home", "parent", "child"]
 
 
@@ -44,17 +58,23 @@ def on_click(e):
 with SinglePageLayout(server) as layout:
     layout.title.set_text("List Browser")
     with layout.content:
-        trame.ListBrowser(
-            classes="pa-8",
-            location=("[100, 100]",),
-            handle_position="bottom",
-            filter=True,
-            list=("listing", FILE_LISTING),
-            path=("path", PATH_HIERARCHY),
-            click=(on_click, "[$event]"),
-            path_separator="/",
-            show_path_with_icon=True,
-        )
+        with v3.VContainer(
+            style=(
+                "height:50%;width:50%;margin-left: auto;margin-right: auto; margin-top: 50px;"
+                " border: 1px solid red;"
+            )
+        ):
+            trame.ListBrowser(
+                classes="pa-8",
+                location=("[100, 100]",),
+                handle_position="bottom",
+                filter=True,
+                list=("listing", FILE_LISTING),
+                path=("path", PATH_HIERARCHY),
+                click=(on_click, "[$event]"),
+                path_separator="/",
+                show_path_with_icon=True,
+            )
 
 if __name__ == "__main__":
     server.start()

--- a/trame_components/widgets/trame.py
+++ b/trame_components/widgets/trame.py
@@ -281,9 +281,9 @@ class ListBrowser(HtmlElement):
     :param list: List stored in state
     :param filter: Function to filter list
     :param path_separator: The icon to use for the slash between folders
-    :param show_path_with_icon: Show the path next to the icon?
-    :param show_icon: Show the folder icon?
-    :param path_as_icon: Use the foldername itself as the icon?
+    :param show_path_with_icon: Shows the path with the icon
+    :param show_icon: Show the folder icon in the navigation bar
+    :param sticky_header: Freezes the navigation bar while scrolling
     :param path_icon:
     :param path_selected_icon:
     :param filter_icon:
@@ -299,6 +299,7 @@ class ListBrowser(HtmlElement):
             "show_icon",
             "show_path_with_icon",
             "filter_icon",
+            "sticky_header",
             "filter",
             "path",
             "list",

--- a/trame_components/widgets/trame.py
+++ b/trame_components/widgets/trame.py
@@ -279,6 +279,7 @@ class ListBrowser(HtmlElement):
 
     :param list: List stored in state
     :param filter: Function to filter list
+    :param path_slash_icon: The icon to use for the slash between folders
     :param path_icon:
     :param path_selected_icon:
     :param filter_icon:
@@ -290,11 +291,11 @@ class ListBrowser(HtmlElement):
         self._attr_names += [
             "path_icon",
             "path_selected_icon",
+            "path_slash_style",
             "filter_icon",
             "filter",
             "path",
             "list",
-            "path_slash_style",
             ("query", "filterQuery"),
         ]
 

--- a/trame_components/widgets/trame.py
+++ b/trame_components/widgets/trame.py
@@ -1,4 +1,5 @@
 from trame_client.widgets.core import AbstractElement
+
 from trame_components import module
 
 __all__ = [
@@ -279,7 +280,10 @@ class ListBrowser(HtmlElement):
 
     :param list: List stored in state
     :param filter: Function to filter list
-    :param path_slash_icon: The icon to use for the slash between folders
+    :param path_separator: The icon to use for the slash between folders
+    :param show_path_with_icon: Show the path next to the icon?
+    :param show_icon: Show the folder icon?
+    :param path_as_icon: Use the foldername itself as the icon?
     :param path_icon:
     :param path_selected_icon:
     :param filter_icon:
@@ -291,7 +295,9 @@ class ListBrowser(HtmlElement):
         self._attr_names += [
             "path_icon",
             "path_selected_icon",
-            "path_slash_style",
+            "path_separator",
+            "show_icon",
+            "show_path_with_icon",
             "filter_icon",
             "filter",
             "path",

--- a/trame_components/widgets/trame.py
+++ b/trame_components/widgets/trame.py
@@ -294,6 +294,7 @@ class ListBrowser(HtmlElement):
             "filter",
             "path",
             "list",
+            "path_slash_style",
             ("query", "filterQuery"),
         ]
 

--- a/trame_components/widgets/trame.py
+++ b/trame_components/widgets/trame.py
@@ -282,7 +282,7 @@ class ListBrowser(HtmlElement):
     :param filter: Function to filter list
     :param path_separator: The icon to use for the slash between folders
     :param show_path_with_icon: Shows the path with the icon
-    :param show_icon: Show the folder icon in the navigation bar
+    :param hide_icon: Hide the folder icons in the navigation bar
     :param sticky_header: Freezes the navigation bar while scrolling
     :param path_icon:
     :param path_selected_icon:
@@ -296,7 +296,7 @@ class ListBrowser(HtmlElement):
             "path_icon",
             "path_selected_icon",
             "path_separator",
-            "show_icon",
+            "hide_icon",
             "show_path_with_icon",
             "filter_icon",
             "sticky_header",

--- a/vue-components/src/components/TrameListBrowser.js
+++ b/vue-components/src/components/TrameListBrowser.js
@@ -63,6 +63,10 @@ export default {
       type: String,
       default: "mdi-folder",
     },
+    pathSlashStyle: {
+      type: String,
+      default: ">",
+    },
     filterIcon: {
       type: String,
       default: "mdi-magnify",
@@ -150,7 +154,7 @@ export default {
         <v-divider v-if="path" class="mb-3" />
         <v-row v-if="path" class="mx-2 py-2 rounded-0 align-center">
             <div v-for="item, idx in path" :key="idx" class="d-flex">
-                <span v-if="idx">></span>
+                <span v-if="idx">{{pathSlashStyle}}</span>
                 <v-icon
                     class="mx-1"
                     ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"

--- a/vue-components/src/components/TrameListBrowser.js
+++ b/vue-components/src/components/TrameListBrowser.js
@@ -57,15 +57,15 @@ export default {
   props: {
     showPathWithIcon: {
       type: Boolean,
-      default: false
+      default: false,
     },
     pathIcon: {
       type: String,
       default: "mdi-folder-outline",
     },
-    showIcon: {
+    hideIcon: {
       type: Boolean,
-      default: true
+      default: false,
     },
     pathSelectedIcon: {
       type: String,
@@ -121,7 +121,7 @@ export default {
           return true;
         }
         const txt = [item.text.toLowerCase(), item.type.toLowerCase()].join(
-          "  "
+          "  ",
         );
         const tokens = filterValues.value;
         for (let i = 0; i < tokens.length; i++) {
@@ -173,7 +173,7 @@ export default {
                 @mouseenter="activatePath(idx)"
                 @mouseleave="deactivatePath">
                 <v-icon
-                  v-if="showIcon"
+                  v-if="!hideIcon"
                   class="mx-1"
                   ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
                 />

--- a/vue-components/src/components/TrameListBrowser.js
+++ b/vue-components/src/components/TrameListBrowser.js
@@ -164,20 +164,20 @@ export default {
         <v-row v-if="path" class="mx-2 py-2 rounded-0 align-center">
             <div v-for="item, idx in path" :key="idx" class="d-flex" >
                 <span v-if="idx">&nbsp; {{ pathSeparator }} &nbsp;</span>
-                <v-icon
-                    v-if="showIcon"
-                    class="mx-1"
-                    ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
-                    @click="goToPath(idx)"
-                    @mouseenter="activatePath(idx)"
-                    @mouseleave="deactivatePath"
-                />
-                <span v-if="showPathWithIcon"
+                <div
                     @click="goToPath(idx)"
                     @mouseenter="activatePath(idx)"
                     @mouseleave="deactivatePath">
-                    {{path[idx]}}
-                </span>
+                    <v-icon
+                        v-if="showIcon"
+                        class="mx-1"
+                        ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
+                    />
+                    <span v-if="showPathWithIcon"
+                        :style="{ textDecoration: activeFolderIndex === idx ? 'underline' : 'none'}">
+                        {{path[idx]}}
+                    </span>
+                </div>
             </div>
             <div v-if="!showPathWithIcon"class="text-truncate text-body-2 pl-1">{{ activeFolderName }}</div>
         </v-row>

--- a/vue-components/src/components/TrameListBrowser.js
+++ b/vue-components/src/components/TrameListBrowser.js
@@ -55,15 +55,24 @@ const QUERY =
 
 export default {
   props: {
+    showPathWithIcon: {
+      type: Boolean,
+      default: false
+    },
     pathIcon: {
       type: String,
       default: "mdi-folder-outline",
     },
+    showIcon: {
+      type: Boolean,
+      default: true
+    },
+    // showIcon, showPathWithIcon, separ
     pathSelectedIcon: {
       type: String,
       default: "mdi-folder",
     },
-    pathSlashStyle: {
+    pathSeparator: {
       type: String,
       default: ">",
     },
@@ -153,17 +162,24 @@ export default {
     <v-col class="pa-0">
         <v-divider v-if="path" class="mb-3" />
         <v-row v-if="path" class="mx-2 py-2 rounded-0 align-center">
-            <div v-for="item, idx in path" :key="idx" class="d-flex">
-                <span v-if="idx">{{pathSlashStyle}}</span>
+            <div v-for="item, idx in path" :key="idx" class="d-flex" >
+                <span v-if="idx">&nbsp; {{ pathSeparator }} &nbsp;</span>
                 <v-icon
+                    v-if="showIcon"
                     class="mx-1"
                     ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
                     @click="goToPath(idx)"
                     @mouseenter="activatePath(idx)"
                     @mouseleave="deactivatePath"
                 />
+                <span v-if="showPathWithIcon"
+                    @click="goToPath(idx)"
+                    @mouseenter="activatePath(idx)"
+                    @mouseleave="deactivatePath">
+                    {{path[idx]}}
+                </span>
             </div>
-            <div class="text-truncate text-body-2 pl-1">{{ activeFolderName }}</div>
+            <div v-if="!showPathWithIcon"class="text-truncate text-body-2 pl-1">{{ activeFolderName }}</div>
         </v-row>
         <v-divider v-if="path" class="mt-3" />
         <v-row v-if="filter" class="px-2 py-0 ma-0" :class="{ 'mt-3': path }">

--- a/vue-components/src/components/TrameListBrowser.js
+++ b/vue-components/src/components/TrameListBrowser.js
@@ -67,7 +67,6 @@ export default {
       type: Boolean,
       default: true
     },
-    // showIcon, showPathWithIcon, separ
     pathSelectedIcon: {
       type: String,
       default: "mdi-folder",
@@ -95,19 +94,13 @@ export default {
     },
     stickyHeader: {
       type: Boolean,
-      default: true,
+      default: false,
     },
   },
   emits: ["click"],
   setup(props, { emit }) {
     const filterText = ref("");
     const activeFolderIndex = ref(-1);
-    const stickyHeaderStyle = ref({
-      position: "sticky",
-      width: "100%",
-      zIndex: 999,
-    });
-
     const filterValues = computed(() => {
       if (props.filterQuery) {
         return props.filterQuery.toLowerCase().split(" ");
@@ -164,49 +157,48 @@ export default {
       activeFolderIndex,
       filterValues,
       activeFolderName,
-      stickyHeaderStyle,
       ...methods,
     };
   },
 
   template: `
-      <v-col style="padding: 0 !important; height: 100%; display: flex; flex-direction: column;">
-        <v-sheet :style=" stickyHeader ? stickyHeaderStyle : {}">
+      <v-col style="padding: 0 !important; height: 100%; display: flex; flex-direction: column;" :style="{ overflow: stickyHeader ? 'none' : 'auto'}">
+        <v-sheet>
           <v-divider v-if="path" class="mb-3" />
           <v-row v-if="path" class="mx-2 py-2 rounded-0 align-center">
-              <div v-for="item, idx in path" :key="idx" class="d-flex" >
-                  <span v-if="idx">&nbsp; {{ pathSeparator }} &nbsp;</span>
-                  <div
-                      @click="goToPath(idx)"
-                      @mouseenter="activatePath(idx)"
-                      @mouseleave="deactivatePath">
-                      <v-icon
-                          v-if="showIcon"
-                          class="mx-1"
-                          ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
-                      />
-                      <span v-if="showPathWithIcon"
-                          :style="{ textDecoration: activeFolderIndex === idx ? 'underline' : 'none'}">
-                          {{path[idx]}}
-                      </span>
-                  </div>
+            <div v-for="item, idx in path" :key="idx" class="d-flex">
+              <span v-if="idx">&nbsp;{{ pathSeparator }}&nbsp;</span>
+              <div
+                @click="goToPath(idx)"
+                @mouseenter="activatePath(idx)"
+                @mouseleave="deactivatePath">
+                <v-icon
+                  v-if="showIcon"
+                  class="mx-1"
+                  ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
+                />
+                <span v-if="showPathWithIcon"
+                  :style="{ textDecoration: activeFolderIndex === idx ? 'underline' : 'none'}">
+                  {{path[idx]}}
+                </span>
               </div>
-              <div v-if="!showPathWithIcon"class="text-truncate text-body-2 pl-1">{{ activeFolderName }}</div>
+            </div>
+            <div v-if="!showPathWithIcon"class="text-truncate text-body-2 pl-1">{{ activeFolderName }}</div>
           </v-row>
           <v-divider v-if="path" class="mt-3" />
           <v-row v-if="filter" class="px-2 py-0 ma-0" :class="{ 'mt-3': path }">
-              ${QUERY}
+            ${QUERY}
           </v-row>
         </v-sheet>
-        <v-list dense v-if="list" class="overflow-y-auto" fill-height>
-            <v-list-item
-                v-for="(item, i) in list"
-                :key="i"
-                @click="selectItem(i)"
-                v-show="show(item)"
-            >
-              ${LIST_ITEM}
-            </v-list-item>
+        <v-list dense v-if="list" fill-height :style="{ overflow: stickyHeader ? 'auto' : 'initial'}">
+          <v-list-item
+            v-for="(item, i) in list"
+              :key="i"
+              @click="selectItem(i)"
+              v-show="show(item)"
+          >
+            ${LIST_ITEM}
+          </v-list-item>
         </v-list>
       </v-col>
     `,

--- a/vue-components/src/components/TrameListBrowser.js
+++ b/vue-components/src/components/TrameListBrowser.js
@@ -93,11 +93,20 @@ export default {
     filterQuery: {
       type: String,
     },
+    stickyHeader: {
+      type: Boolean,
+      default: true,
+    },
   },
   emits: ["click"],
   setup(props, { emit }) {
     const filterText = ref("");
     const activeFolderIndex = ref(-1);
+    const stickyHeaderStyle = ref({
+      position: "sticky",
+      width: "100%",
+      zIndex: 999,
+    });
 
     const filterValues = computed(() => {
       if (props.filterQuery) {
@@ -155,36 +164,40 @@ export default {
       activeFolderIndex,
       filterValues,
       activeFolderName,
+      stickyHeaderStyle,
       ...methods,
     };
   },
+
   template: `
-    <v-col class="pa-0">
-        <v-divider v-if="path" class="mb-3" />
-        <v-row v-if="path" class="mx-2 py-2 rounded-0 align-center">
-            <div v-for="item, idx in path" :key="idx" class="d-flex" >
-                <span v-if="idx">&nbsp; {{ pathSeparator }} &nbsp;</span>
-                <div
-                    @click="goToPath(idx)"
-                    @mouseenter="activatePath(idx)"
-                    @mouseleave="deactivatePath">
-                    <v-icon
-                        v-if="showIcon"
-                        class="mx-1"
-                        ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
-                    />
-                    <span v-if="showPathWithIcon"
-                        :style="{ textDecoration: activeFolderIndex === idx ? 'underline' : 'none'}">
-                        {{path[idx]}}
-                    </span>
-                </div>
-            </div>
-            <div v-if="!showPathWithIcon"class="text-truncate text-body-2 pl-1">{{ activeFolderName }}</div>
-        </v-row>
-        <v-divider v-if="path" class="mt-3" />
-        <v-row v-if="filter" class="px-2 py-0 ma-0" :class="{ 'mt-3': path }">
-            ${QUERY}
-        </v-row>
+      <v-col style="padding: 0 !important; height: 100%; display: flex; flex-direction: column;">
+        <v-sheet :style=" stickyHeader ? stickyHeaderStyle : {}">
+          <v-divider v-if="path" class="mb-3" />
+          <v-row v-if="path" class="mx-2 py-2 rounded-0 align-center">
+              <div v-for="item, idx in path" :key="idx" class="d-flex" >
+                  <span v-if="idx">&nbsp; {{ pathSeparator }} &nbsp;</span>
+                  <div
+                      @click="goToPath(idx)"
+                      @mouseenter="activatePath(idx)"
+                      @mouseleave="deactivatePath">
+                      <v-icon
+                          v-if="showIcon"
+                          class="mx-1"
+                          ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
+                      />
+                      <span v-if="showPathWithIcon"
+                          :style="{ textDecoration: activeFolderIndex === idx ? 'underline' : 'none'}">
+                          {{path[idx]}}
+                      </span>
+                  </div>
+              </div>
+              <div v-if="!showPathWithIcon"class="text-truncate text-body-2 pl-1">{{ activeFolderName }}</div>
+          </v-row>
+          <v-divider v-if="path" class="mt-3" />
+          <v-row v-if="filter" class="px-2 py-0 ma-0" :class="{ 'mt-3': path }">
+              ${QUERY}
+          </v-row>
+        </v-sheet>
         <v-list dense v-if="list" class="overflow-y-auto" fill-height>
             <v-list-item
                 v-for="(item, i) in list"
@@ -195,6 +208,6 @@ export default {
               ${LIST_ITEM}
             </v-list-item>
         </v-list>
-    </v-col>
+      </v-col>
     `,
 };


### PR DESCRIPTION
This merge will improve the ListBrowser component by providing more customization options and fixing overflow behavior. This is fully backwards-compatible with the previous version.

## Changes
### ListBrowser now nests within a parent element cleanly
Before:
![chrome_hRdx8FjZVe](https://github.com/user-attachments/assets/d4826c8d-3cfa-4258-9474-601dec7c642f)

After:
![chrome_1vGzINQODN](https://github.com/user-attachments/assets/9b3018da-0615-4f6b-a381-cd714a8a7c10)

### New Customization
The user can now specify the following variables:
* `path_separator`: The path separator can be specified. By default, this is `>` like normal
* `show_path_with_icon`: Can allow the user to see what each folder leads to. These are _also_ clickable just like the original folders and underline when hovered
* `show_icon`: Whether to show the folder icon, defaults to true
* `sticky_header`: Whether to have the header be stuck to the top, useful for situations where there's many elements. Defaults to false to mimic former behavior