### PR TITLE
ListBrowser Mouse Pointers

### DIFF
--- a/vue-components/src/components/TrameListBrowser.js
+++ b/vue-components/src/components/TrameListBrowser.js
@@ -167,7 +167,7 @@ export default {
           <v-divider v-if="path" class="mb-3" />
           <v-row v-if="path" class="mx-2 py-2 rounded-0 align-center">
             <div v-for="item, idx in path" :key="idx" class="d-flex">
-              <span v-if="idx">&nbsp;{{ pathSeparator }}&nbsp;</span>
+              <span v-if="idx" style="cursor: default">&nbsp;{{ pathSeparator }}&nbsp;</span>
               <div
                 @click="goToPath(idx)"
                 @mouseenter="activatePath(idx)"
@@ -175,9 +175,11 @@ export default {
                 <v-icon
                   v-if="!hideIcon"
                   class="mx-1"
+                  style="cursor: pointer"
                   ${ICON_ATTR}="activeFolderIndex === idx ? pathSelectedIcon : pathIcon"
                 />
                 <span v-if="showPathWithIcon"
+                  style="cursor: pointer"
                   :style="{ textDecoration: activeFolderIndex === idx ? 'underline' : 'none'}">
                   {{path[idx]}}
                 </span>


### PR DESCRIPTION
This merge will make the mouse pointer indicate that the links/icons in the navigation bar are clickable, and the separators to not make the cursor indicate text selection.

## Preview
### Before
![chrome_vGdnRHRa7j](https://github.com/user-attachments/assets/3b173464-63b8-4fd5-8edb-9f52221d4933)

### After
![chrome_Ndm51897s3](https://github.com/user-attachments/assets/0e0e8699-36b4-4e20-89ed-db747d1a4500)
